### PR TITLE
fix: Add missing /api/logs endpoint

### DIFF
--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { workflowRunsTable } from '@/lib/schema';
+import { eq, and, desc } from 'drizzle-orm';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/logs
+ * List workflow execution logs (runs) for the authenticated user
+ * Query params:
+ *   - organizationId: Filter by organization/client
+ *   - limit: Number of logs to return (default: 50, max: 1000)
+ *   - workflowId: Filter by specific workflow
+ */
+export async function GET(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Parse query parameters
+    const { searchParams } = new URL(request.url);
+    const organizationId = searchParams.get('organizationId');
+    const workflowId = searchParams.get('workflowId');
+    const limitParam = searchParams.get('limit');
+    const limit = limitParam ? Math.min(parseInt(limitParam, 10), 1000) : 50;
+
+    // Build where clause
+    const whereConditions = [eq(workflowRunsTable.userId, session.user.id)];
+
+    if (organizationId) {
+      whereConditions.push(eq(workflowRunsTable.organizationId, organizationId));
+    }
+
+    if (workflowId) {
+      whereConditions.push(eq(workflowRunsTable.workflowId, workflowId));
+    }
+
+    // Fetch workflow runs (logs)
+    const logs = await db
+      .select({
+        id: workflowRunsTable.id,
+        workflowId: workflowRunsTable.workflowId,
+        status: workflowRunsTable.status,
+        triggerType: workflowRunsTable.triggerType,
+        triggerData: workflowRunsTable.triggerData,
+        startedAt: workflowRunsTable.startedAt,
+        completedAt: workflowRunsTable.completedAt,
+        duration: workflowRunsTable.duration,
+        output: workflowRunsTable.output,
+        error: workflowRunsTable.error,
+        errorStep: workflowRunsTable.errorStep,
+      })
+      .from(workflowRunsTable)
+      .where(and(...whereConditions))
+      .orderBy(desc(workflowRunsTable.startedAt))
+      .limit(limit);
+
+    logger.info(
+      {
+        userId: session.user.id,
+        organizationId,
+        logCount: logs.length,
+        action: 'logs_fetch_success',
+      },
+      'Workflow logs fetched successfully'
+    );
+
+    return NextResponse.json({ logs, count: logs.length });
+  } catch (error) {
+    logger.error(
+      {
+        error: error instanceof Error ? error.message : String(error),
+        action: 'logs_fetch_failed',
+      },
+      'Failed to fetch workflow logs'
+    );
+    return NextResponse.json(
+      { error: 'Failed to fetch logs' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
This PR adds the missing /api/logs endpoint to resolve JSON parsing errors occurring on the Activity page.

## Issue
When navigating to the Activity page, the frontend attempts to fetch workflow execution logs from the /api/logs endpoint. However, this endpoint was not implemented, resulting in:
- HTTP 404 responses returning HTML error pages instead of JSON
- Console error: SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
- Broken Activity page unable to display workflow execution history

## Solution
Implemented the /api/logs API endpoint (src/app/api/logs/route.ts) with the following functionality:

### Features
- Fetches workflow execution logs from the workflow_runs database table
- Query parameter support: organizationId, workflowId, limit
- Authentication - Requires valid user session
- Multi-tenant support - Filters logs based on user's organization access
- Error handling with structured error responses

### Implementation Details
- Follows existing codebase patterns (similar to /api/workflows endpoint)
- Uses Drizzle ORM for type-safe database queries
- Returns logs ordered by most recent first

## Testing
✅ Activity page loads without console errors
✅ Endpoint returns proper JSON response with 200 status ✅ Authentication properly rejects unauthenticated requests ✅ Organization filtering works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)