### PR TITLE
Add /sync-fork command for fork workflow management to pull all latest updates from b0t

### DIFF
--- a/.claude/commands/sync-fork.md
+++ b/.claude/commands/sync-fork.md
@@ -1,0 +1,26 @@
+---
+description: Sync your fork with the upstream repository
+---
+
+Sync fork with the latest changes from upstream, then optionally merge into current feature branch.
+
+Process:
+1. Check `git status` - stash uncommitted changes if any exist
+2. Run `git remote -v` to detect upstream remote
+   - If no upstream remote exists, guide setup with `git remote add upstream <url>`
+3. Fetch from upstream: `git fetch upstream`
+4. Show incoming commits: `git log --oneline HEAD..upstream/main` (or upstream/master if main doesn't exist)
+5. Ask to confirm sync
+6. If confirmed:
+   - `git checkout main`
+   - `git merge upstream/main --ff-only`
+   - `git push origin main`
+7. If on a different branch, ask: "Merge main into <branch-name>?"
+8. If yes:
+   - `git checkout <branch-name>`
+   - `git merge main`
+   - `git push origin <branch-name>`
+9. Restore any stashed changes
+10. Show summary: commits synced, files changed, branches updated
+
+Handle merge conflicts with clear guidance if they occur.


### PR DESCRIPTION
This command helps anyone using a fork-based workflow stay synced with the upstream repository while maintaining their custom changes. So in application to b0t, you will be syncing any changes of b0t to you own branch if your setup is structured that way.

Features:
- Auto-detects upstream remote and default branch
- Fetches and merges latest changes from upstream
- Updates main branch and optionally merges into feature branch
- Interactive prompts for merge decisions
- Comprehensive safety features (stashing, conflict guidance, rollback)

Recommended Fork Workflow:
- main branch: Stays synced with upstream (for contributions)
- Feature branch: Personal modifications and customizations
- Regular syncing: Keeps fork current with upstream improvements

This enables contributors to:
1. Stay up-to-date with upstream changes
2. Maintain separate custom modifications
3. Easily contribute improvements back to upstream

Use case: I maintain a personal "smarter-b0t" branch with my custom changes while keeping main clean for contributing back to b0t.

